### PR TITLE
Remove details

### DIFF
--- a/templates/cockroachdb
+++ b/templates/cockroachdb
@@ -57,6 +57,10 @@ td {
     height: 50px;
 }
 
+.alnright {
+    text-align: right;
+}
+
 .stats {
     font-family: ArialMT;
     font-size: 12px;
@@ -149,7 +153,7 @@ td {
             {{end}}
           </div>
         </td>
-        <td class="title"><img src="{{ .User.AvatarURL }}" class="avatar"/></td>
+        <td class="title alnright"><img src="{{ .User.AvatarURL }}" class="avatar"/></td>
       </tr>
       <tr class="body">
         <td>
@@ -177,7 +181,7 @@ td {
             {{end}}
           </div>
         </td>
-        <td class="title"><img src="{{ .User.AvatarURL }}" class="avatar"/></td>
+        <td class="title alnright"><img src="{{ .User.AvatarURL }}" class="avatar"/></td>
       </tr>
     </table>
     <div class="spacer">&nbsp</div>

--- a/templates/cockroachdb
+++ b/templates/cockroachdb
@@ -155,13 +155,6 @@ td {
         <td>
           <article class="markdown-body entry-content">
             {{ .Body | markDown }}
-            <details><summary>Commits</summary>
-            <ul>
-            {{ range .CommitMessages }}
-            <li><pre>{{ .Commit.Message }}</pre></li>
-            {{ end }}
-            </ul>
-            </details>
           </article>
         </td>
       </tr>
@@ -185,20 +178,6 @@ td {
           </div>
         </td>
         <td class="title"><img src="{{ .User.AvatarURL }}" class="avatar"/></td>
-      </tr>
-      <tr class="body">
-        <td colspan="2">
-          <article class="markdown-body entry-content">
-            <details><summary>Details</summary>
-            {{ .Body | markDown }}
-            <ul>
-            {{ range .CommitMessages }}
-            <li><pre>{{ .Commit.Message }}</pre></li>
-            {{ end }}
-            </ul>
-            </details>
-          </article>
-        </td>
       </tr>
     </table>
     <div class="spacer">&nbsp</div>


### PR DESCRIPTION
I added fancy `<details>` tags but it turns out that most email HTML viewers
expand and then ignore them, so they did more harm than good. Since
detailed information about any given PR is just a click away, rip out the
sections that would be hidden by default.