### PR TITLE
Cap the div width for PR descriptions

### DIFF
--- a/templates/cockroachdb
+++ b/templates/cockroachdb
@@ -105,6 +105,17 @@ td {
     line-height: 16px;
 }
 
+pre {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    width: 600px;
+    display: inline-block;
+}
+
+article p img {
+    width: 600px;
+}
+
 .spacing {
     line-height: 24px;
 }


### PR DESCRIPTION
We overflowed previously for images (common place for UI PRs) and pre
code blocks. This diff just bound them appropriately.